### PR TITLE
ci: harden workflow GITHUB_TOKEN with least-privilege permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# Restrict GITHUB_TOKEN to read-only at workflow level. Jobs that need
+# write access (publish, deploy) declare their own `permissions:` block.
+permissions:
+  contents: read
+
 jobs:
   # ── Job 1: Lint ────────────────────────────────────────────────────────────
   lint:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,11 @@ env:
   NODE_VERSION: '20'
   REGISTRY: 'https://registry.npmjs.org'
 
+# Restrict GITHUB_TOKEN to read-only at workflow level. Jobs that need
+# write access (publish, deploy) declare their own `permissions:` block.
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish @techknowmad/phyloid


### PR DESCRIPTION
## Summary
- Adds workflow-level `permissions: contents: read` to every GitHub Actions workflow in this repo, restricting the `GITHUB_TOKEN` to read-only by default (CodeQL `actions/missing-workflow-permissions` rule).
- Jobs that need write access (publish, deploy) already declare elevated `permissions:` — no functional change.
- Closes the open code-scanning alerts in this repo.

## Test plan
- [ ] CI pipeline runs successfully against the PR head with workflow-level read-only token.
- [ ] CodeQL re-analysis shows the `actions/missing-workflow-permissions` alerts auto-closed once merged to `main`.

Hardening sweep 2026-05-04 — Platinum Audit.