### PR TITLE
ci(deploy): skip Cloudflare deploy when secrets missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,22 @@ jobs:
           VITE_STRIPE_PRICE_PRO: ${{ secrets.VITE_STRIPE_PRICE_PRO }}
           VITE_STRIPE_PRICE_ENTERPRISE: ${{ secrets.VITE_STRIPE_PRICE_ENTERPRISE }}
 
-      - name: Deploy to Cloudflare Pages
+      - name: Check Cloudflare credentials
+        id: cf_check
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        env:
+          HAS_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
+          HAS_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
+        run: |
+          if [ "$HAS_TOKEN" = "true" ] && [ "$HAS_ACCOUNT" = "true" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::CLOUDFLARE_API_TOKEN or CLOUDFLARE_ACCOUNT_ID not set — skipping deploy. Add them in repo Settings → Secrets and variables → Actions."
+          fi
+
+      - name: Deploy to Cloudflare Pages
+        if: steps.cf_check.outputs.ready == 'true'
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary

The Cloudflare Pages deploy step has been failing on every main push since 2026-05-18 with `Not logged in.` — the repo's `CLOUDFLARE_API_TOKEN` secret is missing or expired. That single failure turns the entire CI red, blocking dependabot PRs from being mergeable.

This PR adds a precheck step that skips the deploy with a yellow warning when either `CLOUDFLARE_API_TOKEN` or `CLOUDFLARE_ACCOUNT_ID` is unset.

**When the secrets ARE set** → deploy runs exactly as before.
**When either is missing** → CI passes with `::warning::CLOUDFLARE_API_TOKEN ... not set` pointing at Settings → Secrets → Actions.

This is a graceful-degradation fix, not the root cause. The actual secret still needs to be set — see the companion tracking issue.

## Test plan
- [x] YAML syntax valid
- [ ] CI on this branch passes (no deploy attempted — this PR isn't on main)
- [ ] Next push to main: deploy step skipped with warning if secret still missing; succeeds normally if secret restored
