### PR TITLE
fix(nl-generator): use Object.hasOwn for prototype safety

### DIFF
--- a/src/world/nl-generator.ts
+++ b/src/world/nl-generator.ts
@@ -88,9 +88,9 @@ export function parseWorldPrompt(prompt: string): WorldIntent {
   let scale = 1;
 
   for (const token of tokens) {
-    if (detail === 2 && token in DETAIL_KEYWORDS) detail = DETAIL_KEYWORDS[token];
-    if (fitnessProfile === "random" && token in FITNESS_KEYWORDS) fitnessProfile = FITNESS_KEYWORDS[token];
-    if (colorHint === null && token in COLOR_MAP) colorHint = COLOR_MAP[token];
+    if (detail === 2 && Object.hasOwn(DETAIL_KEYWORDS, token)) detail = DETAIL_KEYWORDS[token];
+    if (fitnessProfile === "random" && Object.hasOwn(FITNESS_KEYWORDS, token)) fitnessProfile = FITNESS_KEYWORDS[token];
+    if (colorHint === null && Object.hasOwn(COLOR_MAP, token)) colorHint = COLOR_MAP[token];
     // Scale keywords (checked once via token set)
     if (token === "tiny" || token === "small") scale = 0.4;
     else if (token === "large" || token === "big" || token === "huge") { if (scale === 1) scale = 1.8; }


### PR DESCRIPTION
## Summary

Property-based test discovered prototype pollution in NL world generator.

`token in COLOR_MAP` walks the prototype chain — so a prompt containing `__proto__` (or `constructor`, `toString`, etc.) hit the colorHint assignment and `COLOR_MAP["__proto__"]` returned `Object.prototype`. The rest of the code happily threaded the resulting non-array through `[colorHint[0], colorHint[1], colorHint[2]]` and produced genomes with non-finite color channels.

Switched all three keyword-map lookups (`DETAIL_KEYWORDS`, `FITNESS_KEYWORDS`, `COLOR_MAP`) to `Object.hasOwn(map, token)`.

## Reproducer

fast-check seed `-1283947988`, counterexample `["__proto__"]`.

## Test plan
- [x] Reproduced failure locally with pinned seed
- [x] Full local suite 103/103 after fix
- [ ] CI green on this branch
